### PR TITLE
feat: Add automatic Homebrew formula updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,3 +181,55 @@ jobs:
         gh release upload ${{ needs.create-release.outputs.version }} checksums.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew Formula
+    runs-on: ubuntu-latest
+    needs: [create-release, update-checksums]
+    if: needs.create-release.outputs.release_id
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Extract version and calculate SHA256
+      id: release-info
+      run: |
+        VERSION=$(grep '^version =' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        
+        # Download and calculate SHA256 of the source tarball
+        curl -L -o source.tar.gz "https://github.com/${{ github.repository }}/archive/refs/tags/v$VERSION.tar.gz"
+        SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
+        echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+        
+        echo "Version: v$VERSION"
+        echo "SHA256: $SHA256"
+
+    - name: Clone Homebrew tap repository
+      run: |
+        git clone https://${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/DigiBugCat/homebrew-dev-tooling.git homebrew-tap
+      env:
+        HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+    - name: Update Homebrew formula
+      run: |
+        cd homebrew-tap
+        
+        # Configure git
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        
+        # Update the formula
+        sed -i 's|url ".*"|url "https://github.com/${{ github.repository }}/archive/refs/tags/v${{ steps.release-info.outputs.version }}.tar.gz"|' Formula/claude-python-guardrails.rb
+        sed -i 's|sha256 ".*"|sha256 "${{ steps.release-info.outputs.sha256 }}"|' Formula/claude-python-guardrails.rb  
+        sed -i 's|version ".*"|version "${{ steps.release-info.outputs.version }}"|' Formula/claude-python-guardrails.rb
+        
+        # Commit and push changes
+        git add Formula/claude-python-guardrails.rb
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "Update claude-python-guardrails to v${{ steps.release-info.outputs.version }}"
+          git push origin main
+          echo "Successfully updated Homebrew formula to v${{ steps.release-info.outputs.version }}"
+        fi

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -74,6 +74,70 @@ git push origin main
 - Creates GitHub release with version from Cargo.toml
 - Uploads binaries and checksums
 - Generates release notes
+- **Automatically updates Homebrew formula** in the `homebrew-dev-tooling` repository
+
+## Homebrew Formula Automation
+
+The release workflow automatically updates the Homebrew formula when a new release is created.
+
+### Initial Setup (One-time)
+
+To enable Homebrew formula updates, you need to configure a GitHub Personal Access Token:
+
+#### 1. Create Personal Access Token
+
+1. Go to **GitHub Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)**
+2. Click **"Generate new token (classic)"**
+3. Set **Expiration**: `No expiration` (or long-term like 1 year)
+4. Select **Scopes**:
+   - ✅ `repo` (Full control of private repositories)
+   - This allows the workflow to clone and push to your `homebrew-dev-tooling` repository
+
+#### 2. Add Token to Repository Secrets
+
+1. Go to your **claude-python-guardrails** repository
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+3. Click **"New repository secret"**
+4. **Name**: `HOMEBREW_TAP_TOKEN`
+5. **Secret**: Paste the personal access token from step 1
+6. Click **"Add secret"**
+
+#### 3. How It Works
+
+When you push to `main` (creating a new release), the workflow will:
+
+1. **Extract version** from `Cargo.toml`
+2. **Download source tarball** from the GitHub release
+3. **Calculate SHA256** of the source code
+4. **Clone your Homebrew tap** repository (`homebrew-dev-tooling`)
+5. **Update the formula** (`Formula/claude-python-guardrails.rb`) with:
+   - New version number
+   - New download URL
+   - New SHA256 checksum
+6. **Commit and push** the changes automatically
+
+#### 4. What Gets Updated
+
+The formula file will be updated from:
+```ruby
+url "https://github.com/DigiBugCat/claude-python-guardrails/archive/refs/tags/v0.1.0.tar.gz"
+sha256 "b4f9f7ceaad22288c5b7a3b8bb6198868869cf71c6366487b5e633f0f162555f"
+version "0.1.0"
+```
+
+To (for example, v0.1.1):
+```ruby
+url "https://github.com/DigiBugCat/claude-python-guardrails/archive/refs/tags/v0.1.1.tar.gz"
+sha256 "new_calculated_sha256_here"
+version "0.1.1"
+```
+
+#### 5. Troubleshooting
+
+- **Token expired**: Regenerate PAT and update the secret
+- **Permission denied**: Ensure the PAT has `repo` scope
+- **Formula not updating**: Check the workflow logs in the Actions tab
+- **Wrong branch**: Ensure your Homebrew tap uses `main` as the default branch
 
 ## Requirements
 
@@ -81,6 +145,7 @@ git push origin main
 - Code must be formatted (`cargo fmt`)
 - No clippy warnings allowed
 - Version in `Cargo.toml` should be updated for new releases
+- **GitHub PAT configured** for Homebrew automation (see above)
 
 ## Quick Commands
 


### PR DESCRIPTION
## 🚀 Homebrew Formula Automation

This PR adds automatic updates to the `homebrew-dev-tooling` repository whenever a new release is created.

### ✨ Features Added

#### **Automated Homebrew Updates**
- New `update-homebrew` job in the release workflow
- Automatically updates `Formula/claude-python-guardrails.rb` with:
  - New version number from `Cargo.toml`
  - Updated download URL for source tarball  
  - Calculated SHA256 checksum of source code
- Commits and pushes changes to homebrew-dev-tooling repository

#### **Comprehensive Documentation**
- Added detailed setup guide in `WORKFLOW.md`
- Step-by-step instructions for configuring GitHub PAT
- Troubleshooting section for common issues
- Examples of before/after formula updates

### 🔧 Implementation Details

#### **Release Workflow Changes**
- Runs after successful release creation and binary uploads
- Downloads GitHub source tarball and calculates SHA256
- Uses sed commands to update formula fields
- Includes proper git configuration for automated commits

#### **Security & Access**  
- Requires `HOMEBREW_TAP_TOKEN` repository secret
- Uses GitHub PAT with `repo` scope for secure access
- Only runs when new releases are actually created

### 📋 Setup Requirements

**For the automation to work, you need to:**

1. **Create GitHub PAT**: Generate token with `repo` scope
2. **Add Repository Secret**: Add `HOMEBREW_TAP_TOKEN` to secrets
3. **One-time setup**: Follow the guide in `WORKFLOW.md`

### 🎯 Benefits

- ✅ **Zero manual work**: Formula updates happen automatically
- ✅ **Accurate checksums**: SHA256 calculated from actual release tarball
- ✅ **Consistent format**: Uses sed for reliable updates
- ✅ **Error handling**: Checks for changes before committing
- ✅ **Audit trail**: All updates have clear commit messages

### 🧪 Testing Plan

After merging and setting up the PAT:
1. Update version in `Cargo.toml`
2. Push to main to trigger release
3. Verify homebrew-dev-tooling gets updated automatically
4. Test `brew install DigiBugCat/dev-tooling/claude-python-guardrails`

### 🔗 Related

- Homebrew tap: https://github.com/DigiBugCat/homebrew-dev-tooling
- Formula: https://github.com/DigiBugCat/homebrew-dev-tooling/blob/main/Formula/claude-python-guardrails.rb

Ready to make Homebrew updates completely automated! 🍺⚡