### PR TITLE
Version bump to 0.1.1 and package metadata update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "claude-python-guardrails"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Andrew Sulistio <andrew@example.com>"]
-description = "Simple exclusion checker for Python projects using Claude Code"
+description = "Smart Python automation hooks for Claude Code with intelligent linting and testing"
 license = "MIT"
-keywords = ["claude", "python", "exclusion", "guardrails"]
-categories = ["command-line-utilities", "development-tools"]
+keywords = ["claude", "python", "automation", "hooks", "linting"]
+categories = ["command-line-utilities", "development-tools", "development-tools::testing"]
 
 [dependencies]
 # Configuration parsing


### PR DESCRIPTION
## Summary
Version bump and package metadata update following the successful merge of Claude workflows.

## Changes
- **Version**: `0.1.0` → `0.1.1`
- **Description**: Updated to reflect focus on Python automation hooks
- **Keywords**: Updated from `exclusion, guardrails` to `automation, hooks, linting`  
- **Categories**: Added `development-tools::testing`

## Why This Change
- Reflects the enhanced CLI description that better describes the tool's purpose
- Aligns Cargo.toml metadata with the actual tool functionality
- Prepares for proper release tagging with updated package information
- Keywords now accurately represent the automation capabilities

## Release Impact
When merged to main, this will:
- Create a new `v0.1.1` GitHub release automatically 
- Update the Homebrew formula with the new version
- Provide proper package metadata for crate publishing

🤖 Generated with [Claude Code](https://claude.ai/code)