### PR TITLE
Simplify CI: Use Linux only for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,7 @@ env:
 jobs:
   test:
     name: Test Suite
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        rust: [stable]
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -25,7 +21,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@v1
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: stable
         components: rustfmt, clippy
 
     - name: Cache cargo registry


### PR DESCRIPTION
## Summary
- Remove macOS from CI test matrix
- Run tests only on Ubuntu Linux

## Rationale
Linux testing is sufficient for this tool since:
- The code is platform-agnostic Rust
- No platform-specific features are used
- Reduces CI time and complexity

## Testing
CI will validate on Linux after merge.